### PR TITLE
Runme.io depricated

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # @Cryptocurrency
-[![Runme](https://runme.io/static/button.svg)](https://runme.io/run?app_id=ffeb1728-bb05-4d24-98ab-c86e4961bb8c)
+
 ## Aliases
 
 - `@api` resolves to `./src/api/`


### PR DESCRIPTION
Dear partners, due to the next step in Runme service evolution we would need to close access to service from 01.12.2020. With this, we kindly ask you to remove the Runme button from Readme.md before this date.